### PR TITLE
Enable the cleanup func to clean the files in /tmp dir; Improve the imports

### DIFF
--- a/mmic_optim_gmx/__init__.py
+++ b/mmic_optim_gmx/__init__.py
@@ -4,7 +4,6 @@ A short description of the project.
 """
 
 # Add imports here
-from .mmic_optim_gmx import *
 
 # Handle versioneer
 from ._version import get_versions

--- a/mmic_optim_gmx/components/__init__.py
+++ b/mmic_optim_gmx/components/__init__.py
@@ -6,4 +6,8 @@ from .gmx_preprocess_component import *
 from .gmx_compute_component import *
 from .gmx_post_component import *
 
-__all__ = gmx_post_component.__all__ + gmx_compute_component.__all__ + gmx_preprocess_component.__all__
+__all__ = (
+    gmx_post_component.__all__
+    + gmx_compute_component.__all__
+    + gmx_preprocess_component.__all__
+)

--- a/mmic_optim_gmx/components/__init__.py
+++ b/mmic_optim_gmx/components/__init__.py
@@ -5,3 +5,5 @@ from . import gmx_post_component
 from .gmx_preprocess_component import *
 from .gmx_compute_component import *
 from .gmx_post_component import *
+
+__all__ = gmx_post_component.__all__ + gmx_compute_component.__all__ + gmx_preprocess_component.__all__

--- a/mmic_optim_gmx/components/gmx_compute_component.py
+++ b/mmic_optim_gmx/components/gmx_compute_component.py
@@ -51,7 +51,6 @@ class GmxComputeComponent(GenericComponent):
             "tpr_file": tpr_file,
         }
 
-        gro_dir = os.path.dirname(gro_file)
         clean_files, cmd_input_grompp = self.build_input_grompp(input_model)
         rvalue = CmdComponent.compute(cmd_input_grompp)
         self.cleanup(clean_files)  # Del mdp and top file in the working dir
@@ -142,8 +141,6 @@ class GmxComputeComponent(GenericComponent):
             env["OMP_NUM_THREADS"] = str(config.ncores)
 
         scratch_directory = config.scratch_directory if config else None
-
-        clean_files = []
 
         log_file = random_file(suffix=".log")
         trr_file = random_file(suffix=".trr")

--- a/mmic_optim_gmx/components/gmx_compute_component.py
+++ b/mmic_optim_gmx/components/gmx_compute_component.py
@@ -54,11 +54,10 @@ class GmxComputeComponent(GenericComponent):
         gro_dir = os.path.dirname(gro_file)
         clean_files, cmd_input_grompp = self.build_input_grompp(input_model)
         rvalue = CmdComponent.compute(cmd_input_grompp)
-        self.cleanup(clean_files)# Del mdp and top file in the working dir
+        self.cleanup(clean_files)  # Del mdp and top file in the working dir
         self.cleanup([inputs.scratch_dir])
         tpr_file = str(rvalue.outfiles[tpr_file])
         tpr_dir = str(rvalue.scratch_directory)
- 
 
         input_model = {"proc_input": proc_input, "tpr_file": tpr_file}
         cmd_input_mdrun = self.build_input_mdrun(input_model)

--- a/mmic_optim_gmx/components/gmx_compute_component.py
+++ b/mmic_optim_gmx/components/gmx_compute_component.py
@@ -11,6 +11,7 @@ import os
 
 __all__ = ["GmxComputeComponent"]
 
+
 class GmxComputeComponent(GenericComponent):
     @classmethod
     def input(cls):
@@ -189,8 +190,8 @@ class GmxComputeComponent(GenericComponent):
     def parse_output(
         self, output: Dict[str, str], inputs: Dict[str, Any]
     ) -> GmxComputeInput:
-       #stdout = output["stdout"]
-       #stderr = output["stderr"]
+        # stdout = output["stdout"]
+        # stderr = output["stderr"]
         outfiles = output["outfiles"]
 
         traj, conf = outfiles.values()

--- a/mmic_optim_gmx/components/gmx_compute_component.py
+++ b/mmic_optim_gmx/components/gmx_compute_component.py
@@ -1,6 +1,4 @@
 # Import models
-from mmelemental.models.util.output import FileOutput
-from mmelemental.models import Molecule, Trajectory
 from ..models import GmxComputeInput, GmxComputeOutput
 
 # Import components
@@ -11,6 +9,7 @@ from mmic.components.blueprints import GenericComponent
 from typing import Dict, Any, List, Tuple, Optional
 import os
 
+__all__ = ["GmxComputeComponent"]
 
 class GmxComputeComponent(GenericComponent):
     @classmethod
@@ -190,8 +189,8 @@ class GmxComputeComponent(GenericComponent):
     def parse_output(
         self, output: Dict[str, str], inputs: Dict[str, Any]
     ) -> GmxComputeInput:
-        stdout = output["stdout"]
-        stderr = output["stderr"]
+       #stdout = output["stdout"]
+       #stderr = output["stderr"]
         outfiles = output["outfiles"]
 
         traj, conf = outfiles.values()

--- a/mmic_optim_gmx/components/gmx_post_component.py
+++ b/mmic_optim_gmx/components/gmx_post_component.py
@@ -4,13 +4,12 @@ from mmelemental.models import Molecule, Trajectory
 from ..models import GmxComputeOutput
 
 # Import components
-from mmic_cmd.components import CmdComponent
-from mmelemental.util.files import random_file
 from mmic.components.blueprints import GenericComponent
 
-from typing import Dict, Any, List, Tuple, Optional
+from typing import List, Tuple, Optional
 import os
 
+__all__ = ["GmxPostComponent"]
 
 class GmxPostComponent(GenericComponent):
     @classmethod
@@ -39,7 +38,7 @@ class GmxPostComponent(GenericComponent):
         clean_files = []
         traj_file = inputs.trajectory
         print(traj_file)
-        if inputs.proc_input.trajectory == None:
+        if inputs.proc_input.trajectory is None:
             traj_name = list(inputs.proc_input.molecule)[0]
             traj = {traj_name: Trajectory.from_file(traj_file)}
         else:

--- a/mmic_optim_gmx/components/gmx_post_component.py
+++ b/mmic_optim_gmx/components/gmx_post_component.py
@@ -37,7 +37,6 @@ class GmxPostComponent(GenericComponent):
         be applied to single molecule conditions
         """
 
-        clean_files = []
         traj_file = inputs.trajectory
         traj_dir = os.path.dirname(traj_file)
         if inputs.proc_input.trajectory is None:
@@ -50,7 +49,6 @@ class GmxPostComponent(GenericComponent):
                 key: Trajectory.from_file(trajs_files[key])
                 for key in inputs.proc_input.trajectory
             }
-        clean_files.append(traj_file)
 
         mol_file = inputs.molecule
         mol_name = list(inputs.proc_input.molecule)[0]
@@ -59,10 +57,7 @@ class GmxPostComponent(GenericComponent):
             key: Molecule.from_file(mol_files[key])
             for key in inputs.proc_input.molecule
         }
-        clean_files.append(mol_file)
-        print(clean_files)
-        self.cleanup(clean_files)
-        self.cleanup([traj_dir])
+        self.cleanup([inputs.scratch_dir])
 
         return True, OptimOutput(
             proc_input=inputs.proc_input, molecule=mol, trajectory=traj

--- a/mmic_optim_gmx/components/gmx_post_component.py
+++ b/mmic_optim_gmx/components/gmx_post_component.py
@@ -8,6 +8,7 @@ from mmic.components.blueprints import GenericComponent
 
 from typing import List, Tuple, Optional
 import os
+import shutil
 
 __all__ = ["GmxPostComponent"]
 
@@ -38,7 +39,7 @@ class GmxPostComponent(GenericComponent):
 
         clean_files = []
         traj_file = inputs.trajectory
-        print(traj_file)
+        traj_dir = os.path.dirname(traj_file)
         if inputs.proc_input.trajectory is None:
             traj_name = list(inputs.proc_input.molecule)[0]
             traj = {traj_name: Trajectory.from_file(traj_file)}
@@ -52,7 +53,6 @@ class GmxPostComponent(GenericComponent):
         clean_files.append(traj_file)
 
         mol_file = inputs.molecule
-        print(mol_file)
         mol_name = list(inputs.proc_input.molecule)[0]
         mol_files = {mol_name: mol_file}
         mol = {
@@ -62,6 +62,7 @@ class GmxPostComponent(GenericComponent):
         clean_files.append(mol_file)
         print(clean_files)
         self.cleanup(clean_files)
+        self.cleanup([traj_dir])
 
         return True, OptimOutput(
             proc_input=inputs.proc_input, molecule=mol, trajectory=traj

--- a/mmic_optim_gmx/components/gmx_post_component.py
+++ b/mmic_optim_gmx/components/gmx_post_component.py
@@ -38,7 +38,6 @@ class GmxPostComponent(GenericComponent):
         """
 
         traj_file = inputs.trajectory
-        traj_dir = os.path.dirname(traj_file)
         if inputs.proc_input.trajectory is None:
             traj_name = list(inputs.proc_input.molecule)[0]
             traj = {traj_name: Trajectory.from_file(traj_file)}

--- a/mmic_optim_gmx/components/gmx_post_component.py
+++ b/mmic_optim_gmx/components/gmx_post_component.py
@@ -11,6 +11,7 @@ import os
 
 __all__ = ["GmxPostComponent"]
 
+
 class GmxPostComponent(GenericComponent):
     @classmethod
     def input(cls):

--- a/mmic_optim_gmx/components/gmx_preprocess_component.py
+++ b/mmic_optim_gmx/components/gmx_preprocess_component.py
@@ -103,7 +103,7 @@ class GmxPreProcessComponent(GenericComponent):
         boxed_gro_file = random_file(suffix=".gro")
 
         mol.to_file(gro_file, translator="mmic_parmed")
-        ff.to_file(top_file, dtype = "top", translator="mmic_parmed")
+        ff.to_file(top_file, dtype="top", translator="mmic_parmed")
 
         input_model = {
             "gro_file": gro_file,

--- a/mmic_optim_gmx/components/gmx_preprocess_component.py
+++ b/mmic_optim_gmx/components/gmx_preprocess_component.py
@@ -115,6 +115,7 @@ class GmxPreProcessComponent(GenericComponent):
         boxed_gro_file = str(rvalue.outfiles[boxed_gro_file])
         self.cleanup(clean_files)
 
+
         gmx_compute = GmxComputeInput(
             proc_input=inputs,
             mdp_file=mdp_file,

--- a/mmic_optim_gmx/components/gmx_preprocess_component.py
+++ b/mmic_optim_gmx/components/gmx_preprocess_component.py
@@ -103,7 +103,7 @@ class GmxPreProcessComponent(GenericComponent):
         boxed_gro_file = random_file(suffix=".gro")
 
         mol.to_file(gro_file, translator="mmic_parmed")
-        ff.to_file(top_file, translator="mmic_parmed")
+        ff.to_file(top_file, dtype = "top", translator="mmic_parmed")
 
         input_model = {
             "gro_file": gro_file,

--- a/mmic_optim_gmx/components/gmx_preprocess_component.py
+++ b/mmic_optim_gmx/components/gmx_preprocess_component.py
@@ -114,14 +114,14 @@ class GmxPreProcessComponent(GenericComponent):
         rvalue = CmdComponent.compute(cmd_input)
         boxed_gro_file = str(rvalue.outfiles[boxed_gro_file])
         scratch_dir = str(rvalue.scratch_directory)
-        self.cleanup(clean_files)# Del the gro in the working dir
+        self.cleanup(clean_files)  # Del the gro in the working dir
 
         gmx_compute = GmxComputeInput(
             proc_input=inputs,
             mdp_file=mdp_file,
             forcefield=top_file,
             molecule=boxed_gro_file,
-            scratch_dir = scratch_dir,
+            scratch_dir=scratch_dir,
         )
 
         return True, gmx_compute

--- a/mmic_optim_gmx/components/gmx_preprocess_component.py
+++ b/mmic_optim_gmx/components/gmx_preprocess_component.py
@@ -115,7 +115,6 @@ class GmxPreProcessComponent(GenericComponent):
         boxed_gro_file = str(rvalue.outfiles[boxed_gro_file])
         self.cleanup(clean_files)
 
-
         gmx_compute = GmxComputeInput(
             proc_input=inputs,
             mdp_file=mdp_file,

--- a/mmic_optim_gmx/components/gmx_preprocess_component.py
+++ b/mmic_optim_gmx/components/gmx_preprocess_component.py
@@ -113,13 +113,15 @@ class GmxPreProcessComponent(GenericComponent):
         clean_files, cmd_input = self.build_input(input_model)
         rvalue = CmdComponent.compute(cmd_input)
         boxed_gro_file = str(rvalue.outfiles[boxed_gro_file])
-        self.cleanup(clean_files)
+        scratch_dir = str(rvalue.scratch_directory)
+        self.cleanup(clean_files)# Del the gro in the working dir
 
         gmx_compute = GmxComputeInput(
             proc_input=inputs,
             mdp_file=mdp_file,
             forcefield=top_file,
             molecule=boxed_gro_file,
+            scratch_dir = scratch_dir,
         )
 
         return True, gmx_compute

--- a/mmic_optim_gmx/components/gmx_preprocess_component.py
+++ b/mmic_optim_gmx/components/gmx_preprocess_component.py
@@ -103,7 +103,7 @@ class GmxPreProcessComponent(GenericComponent):
         boxed_gro_file = random_file(suffix=".gro")
 
         mol.to_file(gro_file, translator="mmic_parmed")
-        ff.to_file(top_file, dtype="top", translator="mmic_parmed")
+        ff.to_file(top_file, translator="mmic_parmed")
 
         input_model = {
             "gro_file": gro_file,

--- a/mmic_optim_gmx/components/gmx_preprocess_component.py
+++ b/mmic_optim_gmx/components/gmx_preprocess_component.py
@@ -1,14 +1,13 @@
 # Import models
 from mmic_optim.models.input import OptimInput
 from mmic_optim_gmx.models import GmxComputeInput
-from mmelemental.models.util import FileOutput
 from mmelemental.util.files import random_file
 
 # Import components
 from mmic_cmd.components import CmdComponent
 from mmic.components.blueprints import GenericComponent
 
-from typing import Any, Dict, List, Tuple, Optional, Set
+from typing import Any, Dict, List, Tuple, Optional
 import os
 
 __all__ = ["GmxPreProcessComponent"]

--- a/mmic_optim_gmx/models/__init__.py
+++ b/mmic_optim_gmx/models/__init__.py
@@ -1,3 +1,6 @@
 from .input import *
 from .output import *
-from . import input, output
+from . import input
+from . import output
+
+__all__ = input.__all__ + output.__all__

--- a/mmic_optim_gmx/models/input.py
+++ b/mmic_optim_gmx/models/input.py
@@ -2,7 +2,6 @@
 from mmelemental.models.proc.base import ProcInput
 from mmic_optim.models import OptimInput
 from pydantic import Field
-from typing import 
 
 __all__ = ["GmxComputeInput"]
 

--- a/mmic_optim_gmx/models/input.py
+++ b/mmic_optim_gmx/models/input.py
@@ -19,3 +19,8 @@ class GmxComputeInput(ProcInput):
         ...,
         description="The file of the coordinates of the atoms in the system. Should be a .gro file.",
     )
+    
+    scratch_dir: str = Field(
+        ...,
+        description="The path to the directory where the temporary files are written. Generally it's a directory in /tmp"
+    )

--- a/mmic_optim_gmx/models/input.py
+++ b/mmic_optim_gmx/models/input.py
@@ -1,9 +1,10 @@
-from mmelemental.models.base import ProtoModel  # Is this line necessary?
+#from mmelemental.models.base import ProtoModel  # Is this line necessary?
 from mmelemental.models.proc.base import ProcInput
 from mmic_optim.models import OptimInput
 from pydantic import Field
-from typing import Optional
+from typing import 
 
+__all__ = ["GmxComputeInput"]
 
 class GmxComputeInput(ProcInput):
     proc_input: OptimInput = Field(..., description="Procedure input schema.")

--- a/mmic_optim_gmx/models/input.py
+++ b/mmic_optim_gmx/models/input.py
@@ -1,9 +1,10 @@
-#from mmelemental.models.base import ProtoModel  # Is this line necessary?
+# from mmelemental.models.base import ProtoModel  # Is this line necessary?
 from mmelemental.models.proc.base import ProcInput
 from mmic_optim.models import OptimInput
 from pydantic import Field
 
 __all__ = ["GmxComputeInput"]
+
 
 class GmxComputeInput(ProcInput):
     proc_input: OptimInput = Field(..., description="Procedure input schema.")

--- a/mmic_optim_gmx/models/input.py
+++ b/mmic_optim_gmx/models/input.py
@@ -19,8 +19,8 @@ class GmxComputeInput(ProcInput):
         ...,
         description="The file of the coordinates of the atoms in the system. Should be a .gro file.",
     )
-    
+
     scratch_dir: str = Field(
         ...,
-        description="The path to the directory where the temporary files are written. Generally it's a directory in /tmp"
+        description="The path to the directory where the temporary files are written. Generally it's a directory in /tmp",
     )

--- a/mmic_optim_gmx/models/output.py
+++ b/mmic_optim_gmx/models/output.py
@@ -9,4 +9,6 @@ class GmxComputeOutput(ProtoModel):
     proc_input: OptimInput = Field(..., description="Procedure input schema.")
     molecule: str = Field(..., description="Molecule file string object")
     trajectory: str = Field(..., description="Trajectory file string object.")
-    scratch_dir: str = Field(..., description="The dir containing the traj file and the mold file")
+    scratch_dir: str = Field(
+        ..., description="The dir containing the traj file and the mold file"
+    )

--- a/mmic_optim_gmx/models/output.py
+++ b/mmic_optim_gmx/models/output.py
@@ -4,6 +4,7 @@ from pydantic import Field
 
 __all__ = ["GmxComputeOutput"]
 
+
 class GmxComputeOutput(ProtoModel):
     proc_input: OptimInput = Field(..., description="Procedure input schema.")
     molecule: str = Field(..., description="Molecule file string object")

--- a/mmic_optim_gmx/models/output.py
+++ b/mmic_optim_gmx/models/output.py
@@ -9,3 +9,4 @@ class GmxComputeOutput(ProtoModel):
     proc_input: OptimInput = Field(..., description="Procedure input schema.")
     molecule: str = Field(..., description="Molecule file string object")
     trajectory: str = Field(..., description="Trajectory file string object.")
+    scratch_dir: str = Field(..., description="The dir containing the traj file and the mold file")

--- a/mmic_optim_gmx/models/output.py
+++ b/mmic_optim_gmx/models/output.py
@@ -2,6 +2,7 @@ from mmelemental.models.base import ProtoModel
 from mmic_optim.models import OptimInput
 from pydantic import Field
 
+__all__ = ["GmxComputeOutput"]
 
 class GmxComputeOutput(ProtoModel):
     proc_input: OptimInput = Field(..., description="Procedure input schema.")

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ pytest_runner = ["pytest-runner"] if needs_pytest else []
 try:
     with open("README.md", "r") as handle:
         long_description = handle.read()
-except:
+except Exception:
     long_description = "\n".join(short_description[2:])
 
 


### PR DESCRIPTION
## Description
Improve the imports, define __all__, and fix the `cleanup` func in order to delete the files written in /tmp dir

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] Apart from the calls of `cleanup` to eliminate the files in /tmp, there are other calls of this func  used to delete the files in the working dir. Will  keep the useful ones and remove those deleting single files in /tmp (Right now the logic is to delete the whole dir in /tmp when it is useless)
  - [ ] May need to add new var to input/output model in order to use `scratch_directory` feature to access dir name instead of using `os.path.dirname`

## Questions
- [ ] cmd component does not read path. Therefore there are some lines of code converting path to str. Should this be avoided in the future improvement?

## Status
- [ ] Ready to go