### PR TITLE
Add energy and log files as outfiles and fix path filenames

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -11,7 +11,9 @@ dependencies:
   - pip
   - gromacs
     # Testing
+  - codecov
   - pytest
+  - pytest-cov
   - mdanalysis
   
     # Pip-only installs

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -16,8 +16,8 @@ dependencies:
     - codecov
     - pytest
     - pytest-cov
-    - git+https://github.com/MolSSI/cmselemental.git
-    - mmic
+    - git+https://github.com/MolSSI/mmic.git
+    - git+https://github.com/MolSSI/cmselemental.git@v0.2.0
     - git+https://github.com/parmed/parmed.git
     - git+https://github.com/MolSSI/mmic_optim.git
     - git+https://github.com/MolSSI/mmelemental.git

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -9,7 +9,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - gromacs
+    #- gromacs
     # Testing
   - codecov
   - pytest
@@ -18,7 +18,7 @@ dependencies:
   
     # Pip-only installs
   - pip:
-    - cmselemental
+    - git+https://github.com/MolSSI/cmselemental.git 
     - git+https://github.com/parmed/parmed.git
     - mmic
     - git+https://github.com/MolSSI/mmic_optim.git

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -16,7 +16,7 @@ dependencies:
     - codecov
     - pytest
     - pytest-cov
-    - git+https://github.com/MolSSI/cmselemental@v0.2.0
+    - git+https://github.com/MolSSI/cmselemental.git
     - mmic
     - git+https://github.com/parmed/parmed.git
     - git+https://github.com/MolSSI/mmic_optim.git

--- a/mmic_optim_gmx/components/gmx_compute_component.py
+++ b/mmic_optim_gmx/components/gmx_compute_component.py
@@ -3,10 +3,11 @@ from ..models import ComputeGmxInput, ComputeGmxOutput
 
 # Import components
 from mmic_cmd.components import CmdComponent
-from mmelemental.util.files import random_file
+from cmselemental.util.files import random_file
 from mmic.components.blueprints import GenericComponent
 
 from typing import Dict, Any, List, Tuple, Optional
+from pathlib import Path
 import os
 import shutil
 
@@ -44,6 +45,8 @@ class ComputeGmxComponent(GenericComponent):
         )
 
         tpr_file = random_file(suffix=".tpr")
+
+
         input_model = {
             "proc_input": proc_input,
             "mdp_file": mdp_file,
@@ -56,18 +59,15 @@ class ComputeGmxComponent(GenericComponent):
         rvalue = CmdComponent.compute(cmd_input_grompp)
         self.cleanup(clean_files)  # Del mdp and top file in the working dir
         self.cleanup([inputs.scratch_dir])
-        tpr_file = str(rvalue.outfiles[tpr_file])
         tpr_dir = str(rvalue.scratch_directory)
 
         input_model = {"proc_input": proc_input, "tpr_file": tpr_file}
         cmd_input_mdrun = self.build_input_mdrun(input_model)
         rvalue = CmdComponent.compute(cmd_input_mdrun)
+        self.cleanup([tpr_file, gro_file])
         self.cleanup([tpr_dir])
 
-        return True, self.parse_output(
-            rvalue.dict(),
-            proc_input,
-        )
+        return True, self.parse_output(rvalue.dict(), proc_input)
 
     @staticmethod
     def cleanup(remove: List[str]):
@@ -118,15 +118,18 @@ class ComputeGmxComponent(GenericComponent):
         ]
         outfiles = [tpr_file]
 
-        return clean_files, {
-            "command": cmd,
-            "infiles": [inputs["mdp_file"], inputs["gro_file"], inputs["top_file"]],
-            "outfiles": outfiles,
-            "outfiles_track": outfiles,
-            "scratch_directory": scratch_directory,
-            "environment": env,
-            "scratch_messy": True,
-        }
+        return (
+            clean_files,
+            {
+                "command": cmd,
+                "infiles": [inputs["mdp_file"], inputs["gro_file"], inputs["top_file"]],
+                "outfiles": [Path(file).name for file in outfiles],
+                "outfiles_track": [Path(file).name for file in outfiles],
+                "scratch_directory": scratch_directory,
+                "environment": env,
+                "scratch_messy": True,
+            },
+        )
 
     def build_input_mdrun(
         self,
@@ -143,26 +146,29 @@ class ComputeGmxComponent(GenericComponent):
 
         scratch_directory = config.scratch_directory if config else None
 
-        log_file = random_file(suffix=".log")
-        trr_file = random_file(suffix=".trr")
-        edr_file = random_file(suffix=".edr")
-        gro_file = random_file(suffix=".gro")
+        log_fname = Path(random_file(suffix=".log")).name
+        trr_fname = Path(random_file(suffix=".trr")).name
+        edr_fname = Path(random_file(suffix=".edr")).name
+        gro_fname = Path(random_file(suffix=".gro")).name
+
+        tpr_file = inputs["tpr_file"]
 
         cmd = [
             inputs["proc_input"].engine,  # Should here be gmx_mpi?
             "mdrun",
             "-s",
-            inputs["tpr_file"],
+            tpr_file,
             "-o",
-            trr_file,
+            trr_fname,
             "-c",
-            gro_file,
+            gro_fname,
             "-e",
-            edr_file,
+            edr_fname,
             "-g",
-            log_file,
+            log_fname,
         ]
-        outfiles = [trr_file, gro_file]
+        
+        outfiles = [trr_fname, gro_fname, edr_fname, log_fname]
 
         # For extra args
         if inputs["proc_input"].keywords:
@@ -174,7 +180,8 @@ class ComputeGmxComponent(GenericComponent):
 
         return {
             "command": cmd,
-            "as_binary": [inputs["tpr_file"]],
+            "as_binary": [Path(tpr_file).name],
+            "infiles": [tpr_file],
             "outfiles": outfiles,
             "outfiles_track": outfiles,
             "scratch_directory": scratch_directory,
@@ -190,14 +197,12 @@ class ComputeGmxComponent(GenericComponent):
         outfiles = output["outfiles"]
         scratch_dir = str(output["scratch_directory"])
 
-        traj, conf = outfiles.values()
-        traj = str(traj)
-        conf = str(conf)
+        traj, conf, energy, log = outfiles.values()
 
         return self.output()(
             proc_input=inputs,
-            molecule=conf,
-            trajectory=traj,
+            molecule=str(conf),
+            trajectory=str(traj),
             scratch_dir=scratch_dir,
             # stdout=stdout,
             # stderr=stderr,

--- a/mmic_optim_gmx/components/gmx_compute_component.py
+++ b/mmic_optim_gmx/components/gmx_compute_component.py
@@ -46,7 +46,6 @@ class ComputeGmxComponent(GenericComponent):
 
         tpr_file = random_file(suffix=".tpr")
 
-
         input_model = {
             "proc_input": proc_input,
             "mdp_file": mdp_file,
@@ -167,7 +166,7 @@ class ComputeGmxComponent(GenericComponent):
             "-g",
             log_fname,
         ]
-        
+
         outfiles = [trr_fname, gro_fname, edr_fname, log_fname]
 
         # For extra args

--- a/mmic_optim_gmx/components/gmx_optim_component.py
+++ b/mmic_optim_gmx/components/gmx_optim_component.py
@@ -47,7 +47,7 @@ class OptimGmxComponent(TacticComponent):
         raise NotImplementedError
 
     @classmethod
-    def strategy_comp(cls) -> Any:
+    def strategy_comps(cls) -> Any:
         """Returns the strategy component this (tactic) component belongs to.
         Returns
         -------

--- a/mmic_optim_gmx/components/gmx_optim_component.py
+++ b/mmic_optim_gmx/components/gmx_optim_component.py
@@ -53,4 +53,4 @@ class OptimGmxComponent(TacticComponent):
         -------
         Any
         """
-        return set(mmic_optim.components.OptimComponent)
+        return {"mmic_optim"}

--- a/mmic_optim_gmx/components/gmx_post_component.py
+++ b/mmic_optim_gmx/components/gmx_post_component.py
@@ -63,8 +63,8 @@ class PostGmxComponent(GenericComponent):
             proc_input=inputs.proc_input,
             molecule=mol,
             trajectory=traj,
-            schema_name="test",
-            schema_version=1.0,
+            schema_name=inputs.proc_input.schema_name,
+            schema_version=inputs.proc_input.schema_version,
             success=True,
         )
 

--- a/mmic_optim_gmx/components/gmx_prep_component.py
+++ b/mmic_optim_gmx/components/gmx_prep_component.py
@@ -118,8 +118,8 @@ class PrepGmxComponent(GenericComponent):
 
         gmx_compute = ComputeGmxInput(
             proc_input=inputs,
-            schema_name="test",
-            schema_version=1.0,
+            schema_name=inputs.schema_name,
+            schema_version=inputs.schema_version,
             mdp_file=mdp_file,
             forcefield=top_file,
             molecule=boxed_gro_file,

--- a/mmic_optim_gmx/components/gmx_prep_component.py
+++ b/mmic_optim_gmx/components/gmx_prep_component.py
@@ -1,13 +1,14 @@
 # Import models
 from mmic_optim.models.input import OptimInput
 from mmic_optim_gmx.models import ComputeGmxInput
-from mmelemental.util.files import random_file
+from cmselemental.util.files import random_file
 
 # Import components
 from mmic_cmd.components import CmdComponent
 from mmic.components.blueprints import GenericComponent
 
 from typing import Any, Dict, List, Tuple, Optional
+from pathlib import Path
 import os
 
 __all__ = ["PrepGmxComponent"]
@@ -112,7 +113,8 @@ class PrepGmxComponent(GenericComponent):
         }
         clean_files, cmd_input = self.build_input(input_model)
         rvalue = CmdComponent.compute(cmd_input)
-        boxed_gro_file = str(rvalue.outfiles[boxed_gro_file])
+
+        ###boxed_gro_file = str(rvalue.outfiles[boxed_gro_file])
         scratch_dir = str(rvalue.scratch_directory)
         self.cleanup(clean_files)  # Del the gro in the working dir
 
@@ -169,12 +171,15 @@ class PrepGmxComponent(GenericComponent):
         ]
         outfiles = [boxed_gro_file]
 
-        return clean_files, {
-            "command": cmd,
-            "infiles": [inputs["gro_file"]],
-            "outfiles": outfiles,
-            "outfiles_track": outfiles,
-            "scratch_directory": scratch_directory,
-            "environment": env,
-            "scratch_messy": True,
-        }
+        return (
+            clean_files,
+            {
+                "command": cmd,
+                "infiles": [inputs["gro_file"]],
+                "outfiles": [Path(file).name for file in outfiles],
+                "outfiles_track": [Path(file).name for file in outfiles],
+                "scratch_directory": scratch_directory,
+                "environment": env,
+                "scratch_messy": True,
+            },
+        )


### PR DESCRIPTION
## Description
Add energy (.edr) and log files to the list of outfiles. Also the way using `mmic_cmd` is fixed by using `pathlib.Path().name` to obtain the file name. The .tpr file and the .gro file used to initiate the simulation are cleaned after the simulation.

## Todos

  - [x] reformat some code.

## Questions
- [ ] Question1

## Status
- [ ] Need some further edition