### PR TITLE
Abandon the func random_file(). Use tempfile lib to handle files

### DIFF
--- a/mmic_optim_gmx/components/gmx_compute_component.py
+++ b/mmic_optim_gmx/components/gmx_compute_component.py
@@ -3,13 +3,13 @@ from ..models import ComputeGmxInput, ComputeGmxOutput
 
 # Import components
 from mmic_cmd.components import CmdComponent
-from cmselemental.util.files import random_file
 from mmic.components.blueprints import GenericComponent
 
 from typing import Dict, Any, List, Tuple, Optional
 from pathlib import Path
 import os
 import shutil
+import tempfile
 
 
 __all__ = ["ComputeGmxComponent"]
@@ -44,7 +44,7 @@ class ComputeGmxComponent(GenericComponent):
             inputs.forcefield,
         )
 
-        tpr_file = random_file(suffix=".tpr")
+        tpr_file = tempfile.NamedTemporaryFile(suffix=".tpr")
 
 
         input_model = {
@@ -146,10 +146,10 @@ class ComputeGmxComponent(GenericComponent):
 
         scratch_directory = config.scratch_directory if config else None
 
-        log_fname = Path(random_file(suffix=".log")).name
-        trr_fname = Path(random_file(suffix=".trr")).name
-        edr_fname = Path(random_file(suffix=".edr")).name
-        gro_fname = Path(random_file(suffix=".gro")).name
+        log_fname = Path(tempfile.NamedTemporaryFile(suffix=".log")).name
+        trr_fname = Path(tempfile.NamedTemporaryFile(suffix=".trr")).name
+        edr_fname = Path(tempfile.NamedTemporaryFile(suffix=".edr")).name
+        gro_fname = Path(tempfile.NamedTemporaryFile(suffix=".gro")).name
 
         tpr_file = inputs["tpr_file"]
 

--- a/mmic_optim_gmx/components/gmx_post_component.py
+++ b/mmic_optim_gmx/components/gmx_post_component.py
@@ -59,13 +59,16 @@ class PostGmxComponent(GenericComponent):
         }
         self.cleanup([inputs.scratch_dir])
 
-        return True, OptimOutput(
-            proc_input=inputs.proc_input,
-            molecule=mol,
-            trajectory=traj,
-            schema_name=inputs.proc_input.schema_name,
-            schema_version=inputs.proc_input.schema_version,
-            success=True,
+        return (
+            True,
+            OptimOutput(
+                proc_input=inputs.proc_input,
+                molecule=mol,
+                trajectory=traj,
+                schema_name=inputs.proc_input.schema_name,
+                schema_version=inputs.proc_input.schema_version,
+                success=True,
+            ),
         )
 
     @staticmethod

--- a/mmic_optim_gmx/components/gmx_prep_component.py
+++ b/mmic_optim_gmx/components/gmx_prep_component.py
@@ -102,7 +102,7 @@ class PrepGmxComponent(GenericComponent):
 
         gro_file = tempfile.NamedTemporaryFile(suffix=".gro")  # output gro
         top_file = tempfile.NamedTemporaryFile(suffix=".top")
-        boxed_gro_file =tempfile.NamedTemporaryFile(suffix=".gro")
+        boxed_gro_file = tempfile.NamedTemporaryFile(suffix=".gro")
 
         mol.to_file(gro_file, translator="mmic_parmed")
         ff.to_file(top_file, translator="mmic_parmed")

--- a/mmic_optim_gmx/components/gmx_prep_component.py
+++ b/mmic_optim_gmx/components/gmx_prep_component.py
@@ -4,7 +4,7 @@ from mmic_optim_gmx.models import ComputeGmxInput
 
 
 # Import components
-from mmic_cmdent.components import CmdComponent
+from mmic_cmd.components import CmdComponent
 from mmic.compons.blueprints import GenericComponent
 
 from typing import Any, Dict, List, Tuple, Optional

--- a/mmic_optim_gmx/components/gmx_prep_component.py
+++ b/mmic_optim_gmx/components/gmx_prep_component.py
@@ -1,15 +1,16 @@
 # Import models
 from mmic_optim.models.input import OptimInput
 from mmic_optim_gmx.models import ComputeGmxInput
-from cmselemental.util.files import random_file
+
 
 # Import components
-from mmic_cmd.components import CmdComponent
-from mmic.components.blueprints import GenericComponent
+from mmic_cmdent.components import CmdComponent
+from mmic.compons.blueprints import GenericComponent
 
 from typing import Any, Dict, List, Tuple, Optional
 from pathlib import Path
 import os
+import tempfile
 
 __all__ = ["PrepGmxComponent"]
 _supported_solvents = ("spc", "tip3p", "tip4p")
@@ -86,7 +87,7 @@ class PrepGmxComponent(GenericComponent):
         mdp_inputs["pbc"] = pbc
 
         # Write .mdp file
-        mdp_file = random_file(suffix=".mdp")
+        mdp_file = tempfile.NamedTemporaryFile(suffix=".mdp")
         with open(mdp_file, "w") as inp:
             for key, val in mdp_inputs.items():
                 inp.write(f"{key} = {val}\n")
@@ -99,9 +100,9 @@ class PrepGmxComponent(GenericComponent):
         ).pop()  # Here ff_name gets actually the related mol name, but it will not be used
         mol_name, mol = list(mols.items()).pop()
 
-        gro_file = random_file(suffix=".gro")  # output gro
-        top_file = random_file(suffix=".top")
-        boxed_gro_file = random_file(suffix=".gro")
+        gro_file = tempfile.NamedTemporaryFile(suffix=".gro")  # output gro
+        top_file = tempfile.NamedTemporaryFile(suffix=".top")
+        boxed_gro_file =tempfile.NamedTemporaryFile(suffix=".gro")
 
         mol.to_file(gro_file, translator="mmic_parmed")
         ff.to_file(top_file, translator="mmic_parmed")

--- a/mmic_optim_gmx/components/gmx_prep_component.py
+++ b/mmic_optim_gmx/components/gmx_prep_component.py
@@ -5,7 +5,7 @@ from mmic_optim_gmx.models import ComputeGmxInput
 
 # Import components
 from mmic_cmd.components import CmdComponent
-from mmic.compons.blueprints import GenericComponent
+from mmic.components.blueprints import GenericComponent
 
 from typing import Any, Dict, List, Tuple, Optional
 from pathlib import Path


### PR DESCRIPTION
## Description
random_file() was a func used to handle the temporary files in energy minimization, such as tpr file and map file. It was now deleted from the lib cmselemental. Therefore another lib, tempfile, is used to substitute it.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] Parmed should be used to make this repo able to handle more than one molecules. It'll be mainly used to combine multiple topology files together to generate the topology of the simulated system. 
  - [ ] A schema file with more than 1 molecules in it is needed from lib mm_data
  - [ ] InputTraj, InputForces and InputOptim will be used in mmic_optim. Therefore this repo needs to be edited to be consistent with it.

## Questions
- [ ]

## Status
- [ ] Needs more edition